### PR TITLE
Fix Article link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # T-Rex game with Processing
 
-This repository contains the code for making our own version of Chrome's T-Rex game! Check full article at <a src = "https://iq.opengenus.org/t-rex-game-with-processing/">iq.opengenus.org/t-rex-game-with-processing/</a>
+This repository contains the code for making our own version of Chrome's T-Rex game! Check full article at <a src = "https://iq.opengenus.org/t-rex-game-java/">https://iq.opengenus.org/t-rex-game-java/</a>
 
 
 <img src = "trexgame.gif">


### PR DESCRIPTION
I was revisiting this repository and realised that the link in the `Readme.md` file doesn't exist. I've replaced the same with the correct link.